### PR TITLE
photobucket: show full (original) res image

### DIFF
--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -2300,7 +2300,7 @@ function makeworld()
 			break;
 		case "photobucket.com":
 			i = document.head.querySelector('meta[property="og:image"] , [name="og:image"]');
-			if(i){i.src = i.content;}
+			if(i){i.src = i.content + "~original";}
 			break;
 		case "freeamateurteens.net":
 		case "img-vidiklub.com":


### PR DESCRIPTION
i updated the script to show the full res version of the image instead of a small size.

i tried doing it the 'right' way by:
-- injecting js to use their function ``Pb.Data.Shared.get(Pb.Data.Shared.MEDIA).originalUrl`` to access the full size image url
-- creating a ``<meta>`` tag with the url to recover it in the userscript through the DOM
but i ran into some kind of a problem.  you can check out my (probably very close to working) attempt here:

https://gist.github.com/ftc2/f82c242c9ee0337e01f1

however, i realized that the full size image url is actually the small size image url with ``~original`` appended, so i just did that instead.