### PR TITLE
Stop execution on Cloudflare MITM guard page.

### DIFF
--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -2185,6 +2185,11 @@ function makeworld()
 	if(!j)
 	{
 		j = true;
+		if (document.title == "Attention Required! | Cloudflare")
+		{
+			console.warn("Cloudflare MITM guard page.  Stopping.");
+			return false;
+		}
 		window.addEventListener('beforescriptexecute', onscript, true);
 	}
 	//


### PR DESCRIPTION
Cloudflare is used as a CDN proxy for many image sites (freeimgup.com,
imgprime.com, pixhost.org, prnt.sc are some of them) and often forces
users to resolve CAPTCHAs before they can access the requested URL.

Currently, when HandyImage runs, those CAPTCHAs do not get displayed,
forcing the user to disable HandyImage, reload the page, resolve the
CAPTCHA, re-enable HandyImage, reload the page.

This patch stops HandyImage execution when it (naively) determines
Cloudflare has intercepted the request, so that the CAPTCHA is properly
displayed and the above manual steps are not required anymore.