### PR TITLE
Allow for https on https://www.porncomix.info

### DIFF
--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -591,7 +591,7 @@
 // @match		http://*.sendpic.org/view/*
 // @match		http*://www.porncomix.info/*/*/
 // @exclude		http*://www.porncomix.info/gallery/*
-// @exclude             https://www.porncomix.info/artist/*
+// @exclude             http*://www.porncomix.info/artist/*
 // @match		*://*.picclock.ru/*/*/
 // @match		http://*.svetmonet.ru/*.html
 // @match		http://*.svetmonet.ru/full/

--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -589,8 +589,9 @@
 // @match		*://*.imgkings.com/img*
 // @match		http://*.imagerar.com/img*
 // @match		http://*.sendpic.org/view/*
-// @match		http://www.porncomix.info/*/*/
-// @exclude		http://www.porncomix.info/gallery/*
+// @match		http*://www.porncomix.info/*/*/
+// @exclude		http*://www.porncomix.info/gallery/*
+// @exclude             https://www.porncomix.info/artist/*
 // @match		*://*.picclock.ru/*/*/
 // @match		http://*.svetmonet.ru/*.html
 // @match		http://*.svetmonet.ru/full/


### PR DESCRIPTION
Google Chrome changes the url of http://www.porncomix.info/ to https://www.porncomix.info/. This makes it not possible to use the script there. This PR proposes a change that should work.

There is also an issue where the script runs on an author gallery where it should not work e.g. [this gallery](https://www.porncomix.info/artist/rebecca/).

