### PR TITLE
Remove ads pop-ups on click

### DIFF
--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name		Handy Image
-// @version		2021.02.17
+// @version		2021.02.19
 // @author		Owyn
 // @contributor	ubless607, bitst0rm
 // @namespace	handyimage

--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -1916,14 +1916,6 @@ function makeworld()
 			window.location.href = i.src;
 			break;
 		}
-	case "imgadult.com":
-		j = true;
-		i = q('a.overlay_ad_link');
-		if(i)
-		{
-			i.click();
-			break;
-		}
 	case "imagefolks.com":
 	case "imgcandy.net":
 	case "imageteam.org":
@@ -2349,11 +2341,13 @@ function makeworld()
 			i.submit();
 			break;
 		}
+	case "imgadult.com":
 	case "imgdrive.net":
 	case "imgtaxi.com":
 	case "imgwallet.com":
+		window.adbctipops = window.ctipops = [];
 		j = true;
-		i = q("a.overlay_ad_link");
+		i = q('a.overlay_ad_link');
 		if(i)
 		{
 			i.click();


### PR DESCRIPTION
Empty arrays contain ads urls to prevent opening ads pop-up instead of actual image page when click is triggered.