### PR TITLE
Fix imagefruit.com

### DIFF
--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -111,8 +111,8 @@
 // @match		http://*.picturedip.com/*/*
 // @match		http://*.croftimage.com/img-*
 // @match		https://*.imagedecode.com/img-*
-// @match		http://*.imagefruit.com/img*
-// @match		http://*.imagefruit.com/show*
+// @match		https://*.imagefruit.com/img*
+// @match		https://*.imagefruit.com/show*
 // @match		https://*.miragepics.com/view*
 // @match		http://*.freeimagehosting.net/*
 // @match		http://*.keptarolo.hu/*


### PR DESCRIPTION
Fix imagefruit.com: currently auto redirect to https so http isn't used anymore
example: https://www.imagefruit.com/show/43357/kerstman.jpg