### PR TITLE
Fix for rule34.xxx

### DIFF
--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -1608,7 +1608,7 @@ function makeworld()
 	case "rule34.xxx":
 	case "rule34.us":
 		j = true;
-		i = q('a[href*="/images/"]');
+		i = q('a[href*="/images/"][href*="' + host + '/"]');
 		if(i){use_booru_tags_in_dl_filename(); i.src = i.href;}
 		break;
 	case "rule34hentai.net":


### PR DESCRIPTION
The original filter for rule34.xxx and rule34.us looks for a link with `/images/` in the href. However, some pages contain links to third-party sites which also have `/images/` in their href, thus confusing the script. This fix adds a second attribute selector to ensure the host address is present in the href.

Test link: https://rule34.xxx/index.php?page=post&s=view&id=6939427