### PR TITLE
Add hamsterimg.net as an alternate to hamster.is per notice

### DIFF
--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -910,6 +910,7 @@
 // @match		https://iimg.su/i/*
 // @match		https://radikal.cloud/i/*
 // @match		https://hamster.is/image/*
+// @match		https://hamsterimg.net/image/*
 // @match		https://coomimgs.net/image/*
 // @match		https://javring.com/upload/*
 // @match		https://xcamcovid.com/upload/*

--- a/HandyImage.user.js
+++ b/HandyImage.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name		Handy Image
-// @version		2025.12.07
+// @version		2026.01.09
 // @author		Owyn
 // @contributor	ubless607, bitst0rm
 // @namespace	handyimage
@@ -1445,6 +1445,7 @@ function makeworld()
 	case "coomimgs.net":
 	case "ltdfoto.ru":
 	case "vgy.me":
+	case "hamsterimg.net":
 		i = document.querySelector('meta[property="og:image"], [name="og:image"]');
 		if(i)
 		{


### PR DESCRIPTION
hamster.is is having issues with the domain and have stood up hamsterimg.net as an alternate.